### PR TITLE
Add gulp test tasks

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,0 +1,31 @@
+// プロジェクトのフォルダ類
+const ROOT_DIRS = {
+  src: './src',
+  test: './test',
+  report: './report',
+  tmp: './.tmp',
+};
+
+const PATHS = {
+  script: {
+    src: [
+      `${ROOT_DIRS.src}/scripts/**/*.js`,
+    ],
+    watch: []
+  },
+  test: {
+    src: [
+      `${ROOT_DIRS.test}/**/*.js`,
+    ],
+    watch: []
+  },
+  report: {
+    coverage: `${ROOT_DIRS.report}/coverage`,
+  },
+};
+
+module.exports = {
+  env: process.env.NODE_ENV || 'dev',
+  rootDirs: ROOT_DIRS,
+  paths: PATHS,
+};

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,7 +1,6 @@
 // プロジェクトのフォルダ類
 const ROOT_DIRS = {
   src: './src',
-  test: './test',
   report: './report',
   tmp: './.tmp',
 };
@@ -9,13 +8,13 @@ const ROOT_DIRS = {
 const PATHS = {
   script: {
     src: [
-      `${ROOT_DIRS.src}/scripts/**/*.js`,
+      `${ROOT_DIRS.src}/**/!(*spec|*mock).js`,
     ],
     watch: []
   },
   test: {
     src: [
-      `${ROOT_DIRS.test}/**/*.js`,
+      `${ROOT_DIRS.src}/**/(*spec|*mock).js`,
     ],
     watch: []
   },

--- a/gulp/tasks/report.js
+++ b/gulp/tasks/report.js
@@ -1,0 +1,14 @@
+const gulp = require('gulp');
+
+const config = require('../config');
+const browserSync = require('browser-sync').create();
+
+gulp.task('report:coverage', () => {
+  browserSync.init({
+    server: {
+      baseDir: `${config.paths.report.coverage}`,
+      port: 9001,
+      directory: true,
+    },
+  });
+});

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -1,0 +1,12 @@
+const gulp = require('gulp');
+
+const config = require('../config');
+const Server = require('karma').Server;
+
+gulp.task('test', () => {
+  const server = new Server({
+    configFile: process.cwd() + '/karma.conf.js',
+    singleRun: true,
+  });
+  server.start();
+});

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,101 @@
+// Karma configuration
+// Generated on Wed Dec 02 2015 23:57:07 GMT+0900 (JST)
+const config = require('./gulp/config');
+
+module.exports = function(karmaConfig) {
+
+  function normalizationBrowserName(browser) {
+    return browser.toLowerCase().split(/[ /-]/)[0];
+  }
+
+  karmaConfig.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      `${config.paths.script.src}`,
+      `${config.paths.test.src}`,
+    ],
+
+
+    // list of files to exclude
+    exclude: [],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+      '/src/scripts/**/*.js': ['babel', 'coverage'],
+      '/test/**/*.js': ['babel'],
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['mocha', 'coverage'],
+
+
+    babelPreprocessor: {},
+
+    // optionally, configure the reporter
+    coverageReporter: {
+      instrumenters: {
+        isparta: require('isparta')
+      },
+      instrumenter: {
+        '**/*.js': 'isparta'
+      },
+      instrumenterOptions: {
+        isparta: {},
+      },
+      reporters: [{
+        type: 'text',
+        subdir: normalizationBrowserName,
+      }, {
+        type: 'html',
+        dir: `${config.paths.report.coverage}`,
+        subdir: normalizationBrowserName,
+      }],
+    },
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: false,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['Chrome'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false,
+
+    // Concurrency level
+    // how many browser should be started simultanous
+    concurrency: Infinity
+  })
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -33,8 +33,8 @@ module.exports = function(karmaConfig) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      '/src/scripts/**/*.js': ['babel', 'coverage'],
-      '/test/**/*.js': ['babel'],
+      'src/scripts/**/!(*spec|*mock).js': ['babel', 'coverage'],
+      'src/scripts/**/(*spec|*mock).js': ['babel'],
     },
 
 

--- a/package.json
+++ b/package.json
@@ -19,8 +19,17 @@
   "devDependencies": {
     "babel-core": "^6.2.1",
     "babel-preset-es2015": "^6.1.18",
+    "browser-sync": "^2.10.0",
     "gulp": "^3.9.0",
     "gulp-load-plugins": "^1.1.0",
+    "isparta": "^4.0.0",
+    "jasmine-core": "^2.3.4",
+    "karma": "^0.13.15",
+    "karma-babel-preprocessor": "^6.0.1",
+    "karma-chrome-launcher": "^0.2.2",
+    "karma-coverage": "douglasduteil/karma-coverage#next",
+    "karma-jasmine": "^0.3.6",
+    "karma-mocha-reporter": "^1.1.3",
     "require-dir": "^0.3.0"
   }
 }

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,0 +1,7 @@
+function square() {
+  return [1,2,3,4,5].map((v) => {
+    return v * v;
+  });
+}
+
+console.log(square());

--- a/src/scripts/main.spec.js
+++ b/src/scripts/main.spec.js
@@ -1,0 +1,11 @@
+describe('A suite', () => {
+  it('contains spec with an expectation', () => {
+    expect(true).toBe(true);
+  });
+});
+
+describe('Test square', () => {
+  it('Should be calculated square 1-5', () => {
+    expect(square()).toEqual([1, 4, 9, 16, 25]);
+  });
+});

--- a/test/specs/spec.js
+++ b/test/specs/spec.js
@@ -1,0 +1,11 @@
+describe('A suite', () => {
+  it('contains spec with an expectation', () => {
+    expect(true).toBe(true);
+  });
+});
+
+describe('Test square', () => {
+  it('Should be calculated square 1-5', () => {
+    expect(square()).toEqual([1, 4, 9, 16, 25]);
+  });
+});


### PR DESCRIPTION
## 重点的に見て欲しいところ

**karma.conf.js**

```
  preprocessors: {
      '/src/scripts/**/*.js': ['babel', 'coverage'],
      '/test/**/*.js': ['babel'],
    },
```

今回は本番コードもbabelを使うのでpreprocessorsにbabelを指定してますが大丈夫でしょうか？
旧horyujiではbabelの指定がなかったので念のため確認して欲しいです。
https://github.com/Horyuji/horyuji/blob/master/karma.covorage.conf.js#L13

**report.js**

coverageはブラウザごとにサブフォルダを作成する想定です。
そのため、browser-syncのbaseDirはcoverage直下をディレクトリ参照させてますが、ディレクトリが見えるのでちょっとかっこ悪いような気がしています。
もっと良い方法ありますかね？

他に気になるとこあれば指摘してください。

ref #17 
